### PR TITLE
JS ←→ Native でデータをやり取りできるようにする

### DIFF
--- a/SimpleWallet.xcodeproj/project.pbxproj
+++ b/SimpleWallet.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		97961E5A21284E8400399815 /* WebKitPlus.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97961E5921284E8400399815 /* WebKitPlus.framework */; };
 		97961E5B21284E8400399815 /* WebKitPlus.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 97961E5921284E8400399815 /* WebKitPlus.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		97961E5D2128527700399815 /* Web3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97961E5C2128527700399815 /* Web3ViewController.swift */; };
+		97961E5F21285B1500399815 /* web3.js in Resources */ = {isa = PBXBuildFile; fileRef = 97961E5E21285B1500399815 /* web3.js */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -63,6 +64,7 @@
 		977224B72127C2CD00F26DBD /* KeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KeychainAccess.framework; path = Carthage/Build/iOS/KeychainAccess.framework; sourceTree = "<group>"; };
 		97961E5921284E8400399815 /* WebKitPlus.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKitPlus.framework; path = Carthage/Build/iOS/WebKitPlus.framework; sourceTree = "<group>"; };
 		97961E5C2128527700399815 /* Web3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Web3ViewController.swift; sourceTree = "<group>"; };
+		97961E5E21285B1500399815 /* web3.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = web3.js; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 				97961E5C2128527700399815 /* Web3ViewController.swift */,
 				0C26AB812126C59F00170732 /* Assets.xcassets */,
 				0C26AB832126C59F00170732 /* LaunchScreen.storyboard */,
+				97961E5E21285B1500399815 /* web3.js */,
 			);
 			path = SimpleWallet;
 			sourceTree = "<group>";
@@ -190,6 +193,7 @@
 				0C26AB9B2126C5BB00170732 /* Main.storyboard in Resources */,
 				0C26AB852126C59F00170732 /* LaunchScreen.storyboard in Resources */,
 				0C26AB822126C59F00170732 /* Assets.xcassets in Resources */,
+				97961E5F21285B1500399815 /* web3.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimpleWallet/Web3ViewController.swift
+++ b/SimpleWallet/Web3ViewController.swift
@@ -11,10 +11,21 @@ import WebKit
 import WebKitPlus
 
 class Web3ViewController: UIViewController {
-    public lazy var configuration: WKWebViewConfiguration = WKWebViewConfiguration()
-    public lazy var webView: WKWebView = WKWebView(frame: self.view.frame, configuration: self.configuration)
-    public lazy var uiDelegate: WKUIDelegatePlus = WKUIDelegatePlus(parentViewController: self)
-    public lazy var observer: WebViewObserver = WebViewObserver(obserbee: self.webView)
+    lazy var configuration: WKWebViewConfiguration = {
+        let configuration = WKWebViewConfiguration()
+
+        // web3.js をページがロードされるごとにInjectionする
+        let scriptURL = Bundle.main.path(forResource: "web3", ofType: "js")
+        var scriptContent = try! String(contentsOfFile: scriptURL!, encoding: .utf8)
+        let script = WKUserScript(source: scriptContent, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+        configuration.userContentController.addUserScript(script)
+
+        return configuration
+    }()
+
+    lazy var webView: WKWebView = WKWebView(frame: self.view.frame, configuration: self.configuration)
+    lazy var uiDelegate: WKUIDelegatePlus = WKUIDelegatePlus(parentViewController: self)
+    lazy var observer: WebViewObserver = WebViewObserver(obserbee: self.webView)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SimpleWallet/web3.js
+++ b/SimpleWallet/web3.js
@@ -1,0 +1,2 @@
+var web3 = {};
+console.log("web3.js Injection succeeded");


### PR DESCRIPTION
- web3.js ファイルを用意しました。中身はまだ適当です。
- Webページを読み込むごとに、ページ上で web3.js を実行するようにしました
- Webページ上で `window.webkit.messageHandlers.sendTransaction.postMessage("ほにゃらら")` を実行すると、`func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)` が呼び出されるようになりました。