### PR TITLE
任意の LockScript に対して任意の額を送金するトランザクションを生成できるようにする

### DIFF
--- a/SimpleWallet/ModalViewController.swift
+++ b/SimpleWallet/ModalViewController.swift
@@ -7,8 +7,7 @@
 //
 
 import UIKit
-
-
+import BitcoinKit
 
 class ModalViewController: UIViewController {
 
@@ -45,5 +44,92 @@ class ModalViewController: UIViewController {
                 self?.balanceLabel.text = "残高:\n　\(balance) tBCH"
             }
         })
+    }
+
+    struct Output {
+        let value: Int64
+        let lockScriptTo: Script
+    }
+
+    // 送金額、宛先LockScriptを受け取るとそれに対して必要なInputをかき集めて署名して送る
+    func sendTransaction(to output: Output) {
+        // 1. おつり用のアドレスを決める
+        let changeAddress: Address = AppController.shared.wallet!.publicKey.toCashaddr()
+
+        // 2. UTXOの取得
+        let legacyAddress: String = AppController.shared.wallet!.publicKey.toLegacy().description
+        APIClient().getUnspentOutputs(withAddresses: [legacyAddress], completionHandler: { [weak self] (unspentOutputs: [UnspentOutput]) in
+            guard let strongSelf = self else {
+                return
+            }
+            let utxos = unspentOutputs.map { $0.asUnspentTransaction() }
+            let unsignedTx = strongSelf.createUnsignedTx(to: output.lockScriptTo, amount: output.value, changeAddress: changeAddress, utxos: utxos)
+            let signedTx = strongSelf.signTx(unsignedTx: unsignedTx, keys: [AppController.shared.wallet!.privateKey])
+            let rawTx = signedTx.serialized().hex
+
+            // 7. 署名されたtxをbroadcastする
+            APIClient().postTx(withRawTx: rawTx, completionHandler: { (txid, error) in
+                if let txid = txid {
+                    print("txid = \(txid)")
+                    print("txhash: https://test-bch-insight.bitpay.com/tx/\(txid)")
+                } else {
+                    print("error post \(error ?? "error = nil")")
+                }
+            })
+        })
+    }
+
+    func selectTx(from utxos: [UnspentTransaction], amount: Int64) -> (utxos: [UnspentTransaction], fee: Int64) {
+        return (utxos, 500)
+    }
+
+    func createUnsignedTx(to lockScriptTo: Script, amount: Int64, changeAddress: Address, utxos: [UnspentTransaction]) -> UnsignedTransaction {
+        // 3. 送金に必要なUTXOの選択
+        let (utxos, fee) = selectTx(from: utxos, amount: amount)
+        let totalAmount: Int64 = utxos.reduce(0) { $0 + $1.output.value }
+        let change: Int64 = totalAmount - amount - fee
+
+
+        // 4. LockScriptを書いて、TransactionOutputを作成する
+        let lockScriptChange = Script(address: changeAddress)!
+
+        let toOutput = TransactionOutput(value: amount, lockingScript: lockScriptTo.data)
+        let changeOutput = TransactionOutput(value: change, lockingScript: lockScriptChange.data)
+
+        // 5. UTXOとTransactionOutputを合わせて、UnsignedTransactionを作る
+        let unsignedInputs = utxos.map { TransactionInput(previousOutput: $0.outpoint, signatureScript: Data(), sequence: UInt32.max) }
+        let tx = Transaction(version: 1, inputs: unsignedInputs, outputs: [toOutput, changeOutput], lockTime: 0)
+        return UnsignedTransaction(tx: tx, utxos: utxos)
+    }
+
+    // 6. 署名する
+    public func signTx(unsignedTx: UnsignedTransaction, keys: [PrivateKey]) -> Transaction {
+        var inputsToSign = unsignedTx.tx.inputs
+        var transactionToSign: Transaction {
+            return Transaction(version: unsignedTx.tx.version, inputs: inputsToSign, outputs: unsignedTx.tx.outputs, lockTime: unsignedTx.tx.lockTime)
+        }
+
+        // Signing
+        let hashType = SighashType.BCH.ALL
+        for (i, utxo) in unsignedTx.utxos.enumerated() {
+            let pubkeyHash: Data = Script.getPublicKeyHash(from: utxo.output.lockingScript)
+
+            let keysOfUtxo: [PrivateKey] = keys.filter { $0.publicKey().pubkeyHash == pubkeyHash }
+            guard let key = keysOfUtxo.first else {
+                continue
+            }
+
+            let sighash: Data = transactionToSign.signatureHash(for: utxo.output, inputIndex: i, hashType: SighashType.BCH.ALL)
+            let signature: Data = try! Crypto.sign(sighash, privateKey: key)
+            let txin = inputsToSign[i]
+            let pubkey = key.publicKey()
+
+            // unlockScriptを作る
+            let unlockingScript = Script.buildPublicKeyUnlockingScript(signature: signature, pubkey: pubkey, hashType: hashType)
+
+            // TODO: sequenceの更新
+            inputsToSign[i] = TransactionInput(previousOutput: txin.previousOutput, signatureScript: unlockingScript, sequence: txin.sequence)
+        }
+        return transactionToSign
     }
 }

--- a/SimpleWallet/SendViewController.swift
+++ b/SimpleWallet/SendViewController.swift
@@ -66,12 +66,6 @@ class SendViewController: UIViewController {
         // 4. LockScriptを書いて、TransactionOutputを作成する
         let lockScriptChange = Script(address: changeAddress)!
 
-        // 上のBitcoin Scriptを自分で書いてみよー！
-
-        // OP_RETURNのOutputを作成する
-
-        // OP_CLTVのOutputを作成する
-
         let toOutput = TransactionOutput(value: amount, lockingScript: lockScriptTo.data)
         let changeOutput = TransactionOutput(value: change, lockingScript: lockScriptChange.data)
 

--- a/SimpleWallet/SendViewController.swift
+++ b/SimpleWallet/SendViewController.swift
@@ -23,58 +23,6 @@ class SendViewController: UIViewController {
 
     }
     
-    struct Output {
-        let value: Int64
-        let lockScriptTo: Script
-    }
-    
-    // 送金額、宛先LockScriptを受け取るとそれに対して必要なInputをかき集めて署名して送る
-    public func sendTransaction(to output: Output) {
-        // 1. おつり用のアドレスを決める
-        let changeAddress: Address = AppController.shared.wallet!.publicKey.toCashaddr()
-
-        // 2. UTXOの取得
-        let legacyAddress: String = AppController.shared.wallet!.publicKey.toLegacy().description
-        APIClient().getUnspentOutputs(withAddresses: [legacyAddress], completionHandler: { [weak self] (unspentOutputs: [UnspentOutput]) in
-            guard let strongSelf = self else {
-                return
-            }
-            let utxos = unspentOutputs.map { $0.asUnspentTransaction() }
-            let unsignedTx = strongSelf.createUnsignedTx(to: output.lockScriptTo, amount: output.value, changeAddress: changeAddress, utxos: utxos)
-            let signedTx = strongSelf.signTx(unsignedTx: unsignedTx, keys: [AppController.shared.wallet!.privateKey])
-            let rawTx = signedTx.serialized().hex
-
-            // 7. 署名されたtxをbroadcastする
-            APIClient().postTx(withRawTx: rawTx, completionHandler: { (txid, error) in
-                if let txid = txid {
-                    print("txid = \(txid)")
-                    print("txhash: https://test-bch-insight.bitpay.com/tx/\(txid)")
-                } else {
-                    print("error post \(error ?? "error = nil")")
-                }
-            })
-        })
-    }
-
-    public func createUnsignedTx(to lockScriptTo: Script, amount: Int64, changeAddress: Address, utxos: [UnspentTransaction]) -> UnsignedTransaction {
-        // 3. 送金に必要なUTXOの選択
-        let (utxos, fee) = selectTx(from: utxos, amount: amount)
-        let totalAmount: Int64 = utxos.reduce(0) { $0 + $1.output.value }
-        let change: Int64 = totalAmount - amount - fee
-
-
-        // 4. LockScriptを書いて、TransactionOutputを作成する
-        let lockScriptChange = Script(address: changeAddress)!
-
-        let toOutput = TransactionOutput(value: amount, lockingScript: lockScriptTo.data)
-        let changeOutput = TransactionOutput(value: change, lockingScript: lockScriptChange.data)
-
-        // 5. UTXOとTransactionOutputを合わせて、UnsignedTransactionを作る
-        let unsignedInputs = utxos.map { TransactionInput(previousOutput: $0.outpoint, signatureScript: Data(), sequence: UInt32.max) }
-        let tx = Transaction(version: 1, inputs: unsignedInputs, outputs: [toOutput, changeOutput], lockTime: 0)
-        return UnsignedTransaction(tx: tx, utxos: utxos)
-    }
-    
     private func sendCoins(toAddress: Address, amount: Int64) {
         // 1. おつり用のアドレスを決める
         let changeAddress: Address = AppController.shared.wallet!.publicKey.toCashaddr()

--- a/SimpleWallet/SendViewController.swift
+++ b/SimpleWallet/SendViewController.swift
@@ -23,6 +23,64 @@ class SendViewController: UIViewController {
 
     }
     
+    struct Output {
+        let value: Int64
+        let lockScriptTo: Script
+    }
+    
+    // 送金額、宛先LockScriptを受け取るとそれに対して必要なInputをかき集めて署名して送る
+    public func sendTransaction(to output: Output) {
+        // 1. おつり用のアドレスを決める
+        let changeAddress: Address = AppController.shared.wallet!.publicKey.toCashaddr()
+
+        // 2. UTXOの取得
+        let legacyAddress: String = AppController.shared.wallet!.publicKey.toLegacy().description
+        APIClient().getUnspentOutputs(withAddresses: [legacyAddress], completionHandler: { [weak self] (unspentOutputs: [UnspentOutput]) in
+            guard let strongSelf = self else {
+                return
+            }
+            let utxos = unspentOutputs.map { $0.asUnspentTransaction() }
+            let unsignedTx = strongSelf.createUnsignedTx(to: output.lockScriptTo, amount: output.value, changeAddress: changeAddress, utxos: utxos)
+            let signedTx = strongSelf.signTx(unsignedTx: unsignedTx, keys: [AppController.shared.wallet!.privateKey])
+            let rawTx = signedTx.serialized().hex
+
+            // 7. 署名されたtxをbroadcastする
+            APIClient().postTx(withRawTx: rawTx, completionHandler: { (txid, error) in
+                if let txid = txid {
+                    print("txid = \(txid)")
+                    print("txhash: https://test-bch-insight.bitpay.com/tx/\(txid)")
+                } else {
+                    print("error post \(error ?? "error = nil")")
+                }
+            })
+        })
+    }
+
+    public func createUnsignedTx(to lockScriptTo: Script, amount: Int64, changeAddress: Address, utxos: [UnspentTransaction]) -> UnsignedTransaction {
+        // 3. 送金に必要なUTXOの選択
+        let (utxos, fee) = selectTx(from: utxos, amount: amount)
+        let totalAmount: Int64 = utxos.reduce(0) { $0 + $1.output.value }
+        let change: Int64 = totalAmount - amount - fee
+
+
+        // 4. LockScriptを書いて、TransactionOutputを作成する
+        let lockScriptChange = Script(address: changeAddress)!
+
+        // 上のBitcoin Scriptを自分で書いてみよー！
+
+        // OP_RETURNのOutputを作成する
+
+        // OP_CLTVのOutputを作成する
+
+        let toOutput = TransactionOutput(value: amount, lockingScript: lockScriptTo.data)
+        let changeOutput = TransactionOutput(value: change, lockingScript: lockScriptChange.data)
+
+        // 5. UTXOとTransactionOutputを合わせて、UnsignedTransactionを作る
+        let unsignedInputs = utxos.map { TransactionInput(previousOutput: $0.outpoint, signatureScript: Data(), sequence: UInt32.max) }
+        let tx = Transaction(version: 1, inputs: unsignedInputs, outputs: [toOutput, changeOutput], lockTime: 0)
+        return UnsignedTransaction(tx: tx, utxos: utxos)
+    }
+    
     private func sendCoins(toAddress: Address, amount: Int64) {
         // 1. おつり用のアドレスを決める
         let changeAddress: Address = AppController.shared.wallet!.publicKey.toCashaddr()


### PR DESCRIPTION
sendCoins （任意のアドレスに、任意の額を送金する）を改造して、
sendTransaction （任意のスクリプトに、任意の額を送金する）を作りました。

全体的に既存のものと処理の流れは同じです。